### PR TITLE
4309: pr check part 3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,159 +14,131 @@ pr:
 pool:
   vmImage: 'ubuntu-latest'
 
-jobs: 
-- job: buildAndTest
-  displayName: Build app and run tests
-  steps:
-  - task: DockerInstaller@0
-    inputs:
-      dockerVersion: $(dockerVersion)
-    displayName: 'Docker: Install - $(dockerVersion)'
+steps:
+- task: DockerInstaller@0
+  inputs:
+    dockerVersion: $(dockerVersion)
+  displayName: 'Docker: Install - $(dockerVersion)'
 
-  - task: AzurePowerShell@4
-    displayName: 'Setup Test Database'
-    inputs:
-      azureSubscription: 'NHSAPP-BuyingCatalogue (Non-Prod)'
-      ScriptPath: 'setup-integration-db.ps1'
-      azurePowerShellVersion: LatestVersion
+- task: AzurePowerShell@4
+  displayName: 'Setup Test Database'
+  inputs:
+    azureSubscription: 'NHSAPP-BuyingCatalogue (Non-Prod)'
+    ScriptPath: 'setup-integration-db.ps1'
+    azurePowerShellVersion: LatestVersion
 
-  - task: UseDotNet@2
-    displayName: 'Use DotNet Core $(dotnetVersion)'
-    inputs:
-      packageType: 'sdk'
-      version: $(dotnetVersion)
-      includePreviewVersions: false
+- task: UseDotNet@2
+  displayName: 'Use DotNet Core $(dotnetVersion)'
+  inputs:
+    packageType: 'sdk'
+    version: $(dotnetVersion)
+    includePreviewVersions: false
 
-  - task: DotNetCoreCLI@2
-    displayName: Build
-    inputs:
-      projects: NHSD.BuyingCatalogue.sln
+- task: DotNetCoreCLI@2
+  displayName: Build
+  inputs:
+    projects: NHSD.BuyingCatalogue.sln
 
-  - task: DotNetCoreCLI@2
-    displayName: Publish
-    inputs:
-      command: publish
-      publishWebProjects: false
-      projects: '**/*NHSD.BuyingCatalogue.API.csproj'
-      arguments: ' --configuration Release --output "docker/out"'
-      zipAfterPublish: false
-      modifyOutputPath: false
+- task: DotNetCoreCLI@2
+  displayName: Publish
+  inputs:
+    command: publish
+    publishWebProjects: false
+    projects: '**/*NHSD.BuyingCatalogue.API.csproj'
+    arguments: ' --configuration Release --output "docker/out"'
+    zipAfterPublish: false
+    modifyOutputPath: false
 
-  - script: |
-     docker-compose build --no-cache
-     docker-compose -f "docker/docker-compose.yml" -f "docker/docker-compose.integration.yml" up -d
-     docker ps -a
+- script: |
+    docker-compose build --no-cache
+    docker-compose -f "docker/docker-compose.yml" -f "docker/docker-compose.integration.yml" up -d
+    docker ps -a
    
-    displayName: 'Docker up'
+  displayName: 'Docker up'
 
-  - task: DotNetCoreCLI@2
-    displayName: 'Run unit tests'
-    inputs:
-      command: test
-      projects: |
-       **/*Tests.csproj
-       !**/*IntegrationTests.csproj
-      arguments: '-v n --collect "Code coverage"'
+- task: DotNetCoreCLI@2
+  displayName: 'Run unit tests'
+  inputs:
+    command: test
+    projects: |
+      **/*Tests.csproj
+      !**/*IntegrationTests.csproj
+    arguments: '-v n --collect "Code coverage"'
 
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Integration tests'
-    inputs:
-      command: test
-      projects: '**/*IntegrationTests.csproj'
-      arguments: '  -v n'
+- task: DotNetCoreCLI@2
+  displayName: 'Run Integration tests'
+  inputs:
+    command: test
+    projects: '**/*IntegrationTests.csproj'
+    arguments: '  -v n'
 
-- job: dockerImageBuildAndPush
-  displayName: Build and push docker containers to the acr
-  condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')))
-  dependsOn: buildAndTest
-  steps:
-  - task: DockerInstaller@0
-    inputs:
-      dockerVersion: $(dockerVersion)
-    displayName: 'Docker: Install - $(dockerVersion)'
+- task: DockerCompose@0
+  displayName: 'Docker Build: Dev'
+  inputs:
+    azureSubscription: 'NHSAPP-BuyingCatalogue (Non-Prod)'
+    azureContainerRegistry: '{"loginServer":"gpitfuturesdevacr.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfutures-dev-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturesdevacr"}'
+    dockerComposeFile: 'docker/docker-compose.pipeline.yaml'
+    action: 'Build services'
 
-  - task: UseDotNet@2
-    displayName: 'Use DotNet Core $(dotnetVersion)'
-    inputs:
-      packageType: 'sdk'
-      version: $(dotnetVersion)
-      includePreviewVersions: false
+- task: DockerCompose@0
+  displayName: 'Docker Build: Test'
+  condition: and(succeeded(), ne(variables['build.reason'], 'PullRequest'))
+  inputs:
+    azureSubscription: 'NHSAPP-BuyingCatalogue (Non-Prod)'
+    azureContainerRegistry: '{"loginServer":"gpitfuturestestacr.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfutures-test-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturestestacr"}'
+    dockerComposeFile: 'docker/docker-compose.pipeline.yaml'
+    action: 'Build services'
 
-  - task: DotNetCoreCLI@2
-    displayName: Build
-    inputs:
-      projects: NHSD.BuyingCatalogue.sln
+- task: DockerCompose@0
+  displayName: 'Docker Build: Pre-Prod'
+  condition: and(succeeded(), ne(variables['build.reason'], 'PullRequest'))
+  inputs:
+    azureSubscription: 'NHSAPP-BuyingCatalogue (Non-Prod)'
+    azureContainerRegistry: '{"loginServer":"gpitfuturespprodacr.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfutures-pprod-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturespprodacr"}'
+    dockerComposeFile: 'docker/docker-compose.pipeline.yaml'
+    action: 'Build services'
 
-  - task: DotNetCoreCLI@2
-    displayName: Publish
-    inputs:
-      command: publish
-      publishWebProjects: false
-      projects: '**/*NHSD.BuyingCatalogue.API.csproj'
-      arguments: ' --configuration Release --output "docker/out"'
-      zipAfterPublish: false
-      modifyOutputPath: false
+- task: DockerCompose@0
+  displayName: 'Docker Build: Prod'
+  condition: and(succeeded(), ne(variables['build.reason'], 'PullRequest'))
+  inputs:
+    azureSubscription: 'NHSAPP-BuyingCatalogue (Prod)'
+    azureContainerRegistry: '{"loginServer":"gpitfuturesprodacr.azurecr.io", "id" : "/subscriptions/d1be8dbc-1a9f-4b7b-ba51-037116110e00/resourceGroups/gpitfutures-prod-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturesprodacr"}'
+    dockerComposeFile: 'docker/docker-compose.pipeline.yaml'
+    action: 'Build services'
 
-  - task: DockerCompose@0
-    displayName: 'Docker Build: Dev'
-    inputs:
-      azureSubscription: 'NHSAPP-BuyingCatalogue (Non-Prod)'
-      azureContainerRegistry: '{"loginServer":"gpitfuturesdevacr.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfutures-dev-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturesdevacr"}'
-      dockerComposeFile: 'docker/docker-compose.pipeline.yaml'
-      action: 'Build services'
+- task: DockerCompose@0
+  displayName: 'Docker Push: Dev'
+  condition: and(succeeded(), ne(variables['build.reason'], 'PullRequest'))
+  inputs:
+    azureSubscription: 'NHSAPP-BuyingCatalogue (Non-Prod)'
+    azureContainerRegistry: '{"loginServer":"gpitfuturesdevacr.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfutures-dev-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturesdevacr"}'
+    dockerComposeFile: 'docker/docker-compose.pipeline.yaml'
+    action: 'Push services'
 
-  - task: DockerCompose@0
-    displayName: 'Docker Build: Test'
-    inputs:
-      azureSubscription: 'NHSAPP-BuyingCatalogue (Non-Prod)'
-      azureContainerRegistry: '{"loginServer":"gpitfuturestestacr.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfutures-test-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturestestacr"}'
-      dockerComposeFile: 'docker/docker-compose.pipeline.yaml'
-      action: 'Build services'
+- task: DockerCompose@0
+  displayName: 'Docker Push: Test'
+  condition: and(succeeded(), ne(variables['build.reason'], 'PullRequest'))
+  inputs:
+    azureSubscription: 'NHSAPP-BuyingCatalogue (Non-Prod)'
+    azureContainerRegistry: '{"loginServer":"gpitfuturestestacr.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfutures-test-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturestestacr"}'
+    dockerComposeFile: 'docker/docker-compose.pipeline.yaml'
+    action: 'Push services'
 
-  - task: DockerCompose@0
-    displayName: 'Docker Build: Pre-Prod'
-    inputs:
-      azureSubscription: 'NHSAPP-BuyingCatalogue (Non-Prod)'
-      azureContainerRegistry: '{"loginServer":"gpitfuturespprodacr.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfutures-pprod-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturespprodacr"}'
-      dockerComposeFile: 'docker/docker-compose.pipeline.yaml'
-      action: 'Build services'
+- task: DockerCompose@0
+  displayName: 'Docker Push: Pre-Prod'
+  condition: and(succeeded(), ne(variables['build.reason'], 'PullRequest'))
+  inputs:
+    azureSubscription: 'NHSAPP-BuyingCatalogue (Non-Prod)'
+    azureContainerRegistry: '{"loginServer":"gpitfuturespprodacr.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfutures-pprod-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturespprodacr"}'
+    dockerComposeFile: 'docker/docker-compose.pipeline.yaml'
+    action: 'Push services'
 
-  - task: DockerCompose@0
-    displayName: 'Docker Build: Prod'
-    inputs:
-      azureSubscription: 'NHSAPP-BuyingCatalogue (Prod)'
-      azureContainerRegistry: '{"loginServer":"gpitfuturesprodacr.azurecr.io", "id" : "/subscriptions/d1be8dbc-1a9f-4b7b-ba51-037116110e00/resourceGroups/gpitfutures-prod-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturesprodacr"}'
-      dockerComposeFile: 'docker/docker-compose.pipeline.yaml'
-      action: 'Build services'
-
-  - task: DockerCompose@0
-    displayName: 'Docker Push: Dev'
-    inputs:
-      azureSubscription: 'NHSAPP-BuyingCatalogue (Non-Prod)'
-      azureContainerRegistry: '{"loginServer":"gpitfuturesdevacr.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfutures-dev-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturesdevacr"}'
-      dockerComposeFile: 'docker/docker-compose.pipeline.yaml'
-      action: 'Push services'
-
-  - task: DockerCompose@0
-    displayName: 'Docker Push: Test'
-    inputs:
-      azureSubscription: 'NHSAPP-BuyingCatalogue (Non-Prod)'
-      azureContainerRegistry: '{"loginServer":"gpitfuturestestacr.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfutures-test-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturestestacr"}'
-      dockerComposeFile: 'docker/docker-compose.pipeline.yaml'
-      action: 'Push services'
-
-  - task: DockerCompose@0
-    displayName: 'Docker Push: Pre-Prod'
-    inputs:
-      azureSubscription: 'NHSAPP-BuyingCatalogue (Non-Prod)'
-      azureContainerRegistry: '{"loginServer":"gpitfuturespprodacr.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfutures-pprod-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturespprodacr"}'
-      dockerComposeFile: 'docker/docker-compose.pipeline.yaml'
-      action: 'Push services'
-
-  - task: DockerCompose@0
-    displayName: 'Docker Push: Prod'
-    inputs:
-      azureSubscription: 'NHSAPP-BuyingCatalogue (Prod)'
-      azureContainerRegistry: '{"loginServer":"gpitfuturesprodacr.azurecr.io", "id" : "/subscriptions/d1be8dbc-1a9f-4b7b-ba51-037116110e00/resourceGroups/gpitfutures-prod-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturesprodacr"}'
-      dockerComposeFile: 'docker/docker-compose.pipeline.yaml'
-      action: 'Push services'
+- task: DockerCompose@0
+  displayName: 'Docker Push: Prod'
+  condition: and(succeeded(), ne(variables['build.reason'], 'PullRequest'))
+  inputs:
+    azureSubscription: 'NHSAPP-BuyingCatalogue (Prod)'
+    azureContainerRegistry: '{"loginServer":"gpitfuturesprodacr.azurecr.io", "id" : "/subscriptions/d1be8dbc-1a9f-4b7b-ba51-037116110e00/resourceGroups/gpitfutures-prod-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturesprodacr"}'
+    dockerComposeFile: 'docker/docker-compose.pipeline.yaml'
+    action: 'Push services'


### PR DESCRIPTION
I originally introduced the multiple jobs as a way of having to only specify the conditional check once, and avoid duplication
However because the later 'docker publish' tasks require earlier tasks I ended up with more duplication than if I had just repeated the conditional on each task I don't want to run during a PR. This also added an additional 60 seconds onto the total execution time because the dotnet build tasks needed to run twice.

Looking at the diff in this PR it's clear I've reduced the number of lines by removing the multiple jobs and just repeating the 1 line conditional; simplifying the whole file IMO.

I've also enabled the 'docker image build' task as part of PRs as it might come in as a handy check against people breaking that process - moving file directories, changing credentials, or something