### PR TITLE
7429: Add addresses to rest of stock suppliers

### DIFF
--- a/src/NHSD.BuyingCatalogue.Database/PostDeployment/InsertSuppliers.sql
+++ b/src/NHSD.BuyingCatalogue.Database/PostDeployment/InsertSuppliers.sql
@@ -13,30 +13,30 @@ BEGIN
         @now,
         @emptyGuid);
 
-    INSERT INTO dbo.Supplier(Id, [Name], LegalName, Summary, LastUpdated, LastUpdatedBy)
+    INSERT INTO dbo.Supplier(Id, [Name], LegalName, Summary, [Address], LastUpdated, LastUpdatedBy)
     VALUES
-    ('100001', 'Remedical Software', 'Remedical Limited', 'The Remedical Software', @now, @emptyGuid),
-    ('100002', 'CareShare', 'CareShare Limited', 'The CareShare', @now, @emptyGuid),
-    ('100003', 'Avatar Solutions', 'Avatar Solutions Plc', 'Avatar Solutions', @now, @emptyGuid),
-    ('100004', 'Catterpillar Medworks', 'Catterpillar Medworks Ltd', 'Catterpillar Medworks', @now, @emptyGuid),
-    ('100005', 'Curtis Systems', 'Curtis Systems Ltd', 'Curtis Systems', @now, @emptyGuid),
-    ('100006', 'Clinical Raptor', 'Clinical Raptor Ltd', 'Clinical Raptor', @now, @emptyGuid),
-    ('100007', 'Doc Lightning', 'Doc Lightning Ltd', 'Doc Lightning', @now, @emptyGuid),
-    ('100008', 'Docability Software', 'Docability Ltd', 'Docability Software', @now, @emptyGuid),
-    ('100009', 'Empire Softworks',  'Empire Softworks Plc', 'Empire Softworks', @now, @emptyGuid),
-    ('100010', 'Cure Forward', 'Cure Forward Ltd', 'Cure Forward', @now, @emptyGuid),
-    ('100011', 'Hansa Healthcare', 'Hansa Healthcare Plc', 'Hansa Healthcare', @now, @emptyGuid),
-    ('100012', 'Moonlight Intercare', 'Moonlight Intercare', 'Moonlight Intercare', @now, @emptyGuid),
-    ('100013', 'eHealth Development', 'eHealth Development', 'eHealth Development', @now, @emptyGuid),
-    ('100014', 'Dr. Nick', 'Dr. Nick', 'Dr. Nick', @now, @emptyGuid),
-    ('100015', 'Testproof Technology',  'Testproof Technology', 'Testproof Technology', @now, @emptyGuid),
-    ('100016', 'Hojo Health', 'Hojo Health Ltd', 'Hojo Health', @now, @emptyGuid),
-    ('100017', 'Jericho Healthcare', 'Jericho Ltd', 'Jericho Healthcare', @now, @emptyGuid),
-    ('100018', 'Mana Systems', 'Mana Systems', 'Mana Systems', @now, @emptyGuid),
-    ('100019', 'Sunhealth Nanosystems', 'Sunhealth Nanosystems', 'Sunhealth Nanosystems', @now, @emptyGuid),
-    ('100020', 'Oakwood', 'Oakwood Ltd', 'Oakwood', @now, @emptyGuid);
+    ('100001', 'Remedical Software', 'Remedical Limited', 'The Remedical Software', '{"line1": "Remedical Software Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100002', 'CareShare', 'CareShare Limited', 'The CareShare', '{"line1": "CareShare Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100003', 'Avatar Solutions', 'Avatar Solutions Plc', 'Avatar Solutions', '{"line1": "Avatar Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100004', 'Catterpillar Medworks', 'Catterpillar Medworks Ltd', 'Catterpillar Medworks', '{"line1": "Medworks Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100005', 'Curtis Systems', 'Curtis Systems Ltd', 'Curtis Systems', '{"line1": "Curtis Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100006', 'Clinical Raptor', 'Clinical Raptor Ltd', 'Clinical Raptor', '{"line1": "Raptor Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100007', 'Doc Lightning', 'Doc Lightning Ltd', 'Doc Lightning', '{"line1": "Doc Lightning Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100008', 'Docability Software', 'Docability Ltd', 'Docability Software', '{"line1": "Docability Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100009', 'Empire Softworks',  'Empire Softworks Plc', 'Empire Softworks', '{"line1": "Empire Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100010', 'Cure Forward', 'Cure Forward Ltd', 'Cure Forward', '{"line1": "Cure Forward Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100011', 'Hansa Healthcare', 'Hansa Healthcare Plc', 'Hansa Healthcare', '{"line1": "Hansa Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100012', 'Moonlight Intercare', 'Moonlight Intercare', 'Moonlight Intercare', '{"line1": "Moonlight Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100013', 'eHealth Development', 'eHealth Development', 'eHealth Development', '{"line1": "eHealth Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100014', 'Dr. Nick', 'Dr. Nick', 'Dr. Nick', '{"line1": "Simpson Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100015', 'Testproof Technology',  'Testproof Technology', 'Testproof Technology', '{"line1": "Testproof Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100016', 'Hojo Health', 'Hojo Health Ltd', 'Hojo Health', '{"line1": "Hojo Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100017', 'Jericho Healthcare', 'Jericho Ltd', 'Jericho Healthcare', '{"line1": "Jericho Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100018', 'Mana Systems', 'Mana Systems', 'Mana Systems', '{"line1": "Mana Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100019', 'Sunhealth Nanosystems', 'Sunhealth Nanosystems', 'Sunhealth Nanosystems', '{"line1": "Sunhealth Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid),
+    ('100020', 'Oakwood', 'Oakwood Ltd', 'Oakwood', '{"line1": "Oakwood Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',@now, @emptyGuid);
 
-    INSERT INTO dbo.Supplier(Id, [Name], LegalName, Summary, SupplierUrl, LastUpdated, LastUpdatedBy)
+    INSERT INTO dbo.Supplier(Id, [Name], LegalName, Summary, SupplierUrl, [Address], LastUpdated, LastUpdatedBy)
     VALUES
     (
         '99999',
@@ -52,6 +52,7 @@ BEGIN
 
     TRUNCATED FOR DEMO',
         'www.emishealth.com',
+        '{"line1": "NotEmis Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',
         @now,
         @emptyGuid),
     (
@@ -60,6 +61,7 @@ BEGIN
         'NotThe Phoenix Partnership',
         'TPP is a digital health company, committed to delivering world-class healthcare software around the world. Its EHR product, SystmOne, is used by over 7,000 NHS organisations in over 25 different care settings. This includes significant deployments in Acute Hospitals, Emergency Departments, Mental Health services, Social Care services and General Practice. In recent years, TPP has increased its international presence, with live deployments in China and across the Middle East.',
         'https://www.tpp-uk.com/',
+        '{"line1": "NotTPP Tower", "line2": "High Street", "city": "Leeds", "county": "West Yorkshire", "postcode": "LS1 1BB", "country": "UK"}',
         @now,
         @emptyGuid);
 END;


### PR DESCRIPTION
added addresses to all stock suppliers
I need these for the AC tests, and in the real world suppliers are unlikely to not have a registered address