### PR TITLE
Specify version of ASP.NET image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Run the API
-FROM mcr.microsoft.com/dotnet/aspnet:latest AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 COPY out /app
 WORKDIR /app
 EXPOSE 80


### PR DESCRIPTION
Specify the SDK version explicitly so that the correct version of ASP.NET is always used.